### PR TITLE
Fix upstream versions for dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "1.1.0",
 	"description": "Node.js SDK/API interface for my.vmware.com",
 	"license": "MIT",
-	"repository": "apnex/vmw-sdk",
+	"repository": "remkolodder/vmw-sdk",
 	"author": "Andrew Obersnel",
 	"engines": {
 		"node": ">=8"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"nodejs"
 	],
 	"dependencies": {
-		"got": "^11.8.2",
+		"got": "=11.8.2",
 		"npm": "^7.21.0",
 		"tough-cookie": "*"
 	}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "1.1.0",
 	"description": "Node.js SDK/API interface for my.vmware.com",
 	"license": "MIT",
-	"repository": "remkolodder/vmw-sdk",
+	"repository": "apnex/vmw-sdk",
 	"author": "Andrew Obersnel",
 	"engines": {
 		"node": ">=8"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"nodejs"
 	],
 	"dependencies": {
-		"got": "*",
+		"got": "^11.8.2",
 		"npm": "^7.21.0",
 		"tough-cookie": "*"
 	}


### PR DESCRIPTION
The latest versions from Got require "ESM" and a different way of using the code. Require becomes import and more changes like that. To fix this, use the old version that is also in the docker image.